### PR TITLE
feat(vault): add optional name for links

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nazhome",
-  "version": "1.0.0",
+  "version": "2.1.0",
   "scripts": {
     "dev": "node scripts/dev-version.js --dev && vite",
     "build": "node scripts/dev-version.js --prod && vite build",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nazhome",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "scripts": {
     "dev": "node scripts/dev-version.js --dev && vite",
     "build": "node scripts/dev-version.js --prod && vite build",

--- a/src/index.html
+++ b/src/index.html
@@ -511,8 +511,10 @@
     <template id="vaultLinkItemTemplate">
         <div class="vault-link-item">
             <img class="vault-link-icon" alt="">
-            <span class="vault-link-name"></span>
-            <span class="vault-link-url"></span>
+            <div class="vault-link-text">
+                <span class="vault-link-name"></span>
+                <span class="vault-link-url"></span>
+            </div>
             <div class="vault-link-actions">
                 <button class="vault-link-menu" title="More options">
                     <span class="menu-dots-icon">⋮</span>

--- a/src/index.html
+++ b/src/index.html
@@ -486,6 +486,11 @@
                 <h3>Edit Link</h3>
                 <form id="vaultEditForm">
                     <div class="input-group">
+                        <label for="editName">Name (optional):</label>
+                        <input type="text" id="editName" placeholder="Leave empty to use URL">
+                        <small class="help-text">Custom name to display instead of URL</small>
+                    </div>
+                    <div class="input-group">
                         <label for="editUrl">URL:</label>
                         <input type="url" id="editUrl" required>
                     </div>
@@ -503,10 +508,10 @@
         </div>
     </template>
 
-    <!-- Add this to your templates section -->
     <template id="vaultLinkItemTemplate">
         <div class="vault-link-item">
             <img class="vault-link-icon" alt="">
+            <span class="vault-link-name"></span>
             <span class="vault-link-url"></span>
             <div class="vault-link-actions">
                 <button class="vault-link-menu" title="More options">

--- a/src/script.js
+++ b/src/script.js
@@ -2825,7 +2825,7 @@ function createVaultDialog() {
                 // Create new vault link
                 const vaultLink = {
                     url: normalizedUrl,
-                    name: null, // No default name, will show URL
+                    name: new URL(normalizedUrl).hostname.replace('www.', ''), // Use domain as default name
                     addedAt: Date.now()
                 };
 
@@ -2968,7 +2968,7 @@ function openVaultEditDialog(link) {
             const updatedLink = {
                 ...link,
                 url: normalizedUrl,
-                name: nameInput.value.trim() || null,
+                name: nameInput.value.trim() || null, // Set to null if empty string
                 icon: iconInput.value.trim(), // Let resolveFavicon handle the favicon resolution
                 updatedAt: Date.now()
             };

--- a/src/script.js
+++ b/src/script.js
@@ -2825,7 +2825,7 @@ function createVaultDialog() {
                 // Create new vault link
                 const vaultLink = {
                     url: normalizedUrl,
-                    name: new URL(normalizedUrl).hostname.replace('www.', ''),
+                    name: null, // No default name, will show URL
                     addedAt: Date.now()
                 };
 
@@ -2870,7 +2870,24 @@ function updateVaultLinks() {
             icon.src = FALLBACK_ICONS.GLOBE;
         });
         
-        linkItem.querySelector('.vault-link-url').textContent = link.url;
+        // Set name or URL
+        const nameElement = linkItem.querySelector('.vault-link-name');
+        const urlElement = linkItem.querySelector('.vault-link-url');
+        
+        if (link.name) {
+            // Display name if available
+            nameElement.textContent = link.name;
+            nameElement.style.display = 'block';
+            urlElement.textContent = link.url;
+            urlElement.style.display = 'block';
+            urlElement.style.opacity = '0.5';
+            urlElement.style.fontSize = '0.7rem';
+        } else {
+            // Display only URL if no name
+            nameElement.style.display = 'none';
+            urlElement.textContent = link.url;
+            urlElement.style.display = 'block';
+        }
 
         // Add click handler to open link
         linkItem.addEventListener('click', (e) => {
@@ -2921,10 +2938,12 @@ function openVaultEditDialog(link) {
     const editDialog = document.querySelector('.vault-edit-dialog');
     const form = document.getElementById('vaultEditForm');
     const urlInput = document.getElementById('editUrl');
+    const nameInput = document.getElementById('editName');
     const iconInput = document.getElementById('editIcon');
 
     // Populate form with current values
     urlInput.value = link.url;
+    nameInput.value = link.name || '';
     iconInput.value = link.icon || '';
 
     // Handle form submission
@@ -2949,6 +2968,7 @@ function openVaultEditDialog(link) {
             const updatedLink = {
                 ...link,
                 url: normalizedUrl,
+                name: nameInput.value.trim() || null,
                 icon: iconInput.value.trim(), // Let resolveFavicon handle the favicon resolution
                 updatedAt: Date.now()
             };

--- a/src/styles.css
+++ b/src/styles.css
@@ -2512,3 +2512,24 @@ input[type="search"]:focus {
 .attribution a:hover {
     text-decoration: underline;
 }
+
+/* Vault link name and URL styles */
+.vault-link-name {
+    color: white;
+    font-size: 0.9rem;
+    flex: 1;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    font-weight: 500;
+}
+
+.vault-link-url {
+    flex: 1;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    color: rgba(255, 255, 255, 0.8);
+    font-size: 0.85rem;
+    letter-spacing: 0.3px;
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -2198,6 +2198,9 @@ input[type="search"]:focus {
     background: rgba(255, 255, 255, 0.05);
     transition: all 0.2s;
     cursor: pointer;
+    position: relative;
+    gap: 0.8rem;
+    width: 100%;
 }
 
 .vault-link-item:hover {
@@ -2208,9 +2211,9 @@ input[type="search"]:focus {
 .vault-link-icon {
     width: 20px;
     height: 20px;
-    margin-right: 0.8rem;
     object-fit: contain;
     opacity: 0.9;
+    flex-shrink: 0; /* Prevent icon from shrinking */
 }
 
 .vault-link-url {
@@ -2223,14 +2226,13 @@ input[type="search"]:focus {
     letter-spacing: 0.3px;
 }
 
+/* Remove hover effect since the menu is always visible now */
 .vault-link-actions {
     margin-left: 0.5rem;
-    opacity: 0;
+    opacity: 1; /* Always show the menu button */
     transition: opacity 0.2s;
-}
-
-.vault-link-item:hover .vault-link-actions {
-    opacity: 1;
+    display: flex;
+    flex: 0 0 auto; /* Don't grow or shrink */
 }
 
 .vault-link-menu {
@@ -2250,7 +2252,7 @@ input[type="search"]:focus {
 
 .vault-link-dropdown {
     position: absolute;
-    top: 100%;
+    top: 0;
     right: 0;
     background: rgba(32, 33, 36, 0.95);
     border: 1px solid rgba(255, 255, 255, 0.1);
@@ -2263,6 +2265,7 @@ input[type="search"]:focus {
     backdrop-filter: blur(12px);
     -webkit-backdrop-filter: blur(12px);
     box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+    z-index: 10; /* Ensure dropdown is above other elements */
 }
 
 .vault-link-dropdown.show {
@@ -2532,4 +2535,13 @@ input[type="search"]:focus {
     color: rgba(255, 255, 255, 0.8);
     font-size: 0.85rem;
     letter-spacing: 0.3px;
+}
+
+/* Make text container take all available width */
+.vault-link-text {
+    flex: 1;
+    min-width: 0; /* Important for text truncation */
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
 }


### PR DESCRIPTION
- [feat] Add input group for name in vault edit form (src/index.html:486-491)
- [feat] Add span for name in vault link template (index.html:509)
- [refactor] Change default link name to null in new link creation (src/script.js:createVaultDialog:2829)
- [refactor] UpdatevaultLinks display logic for name/URL based on link.name (script.js:updateVaultLinks:2870-2885)
- [feat] Retrieve, populate, and save name input value in edit dialog (script.js:openVaultEditDialog:2924, 2928, 2951)
- [style] Add/modify styles for vault link name and URL display (src/styles.css:2515-2533)
- [chore] Bump package version from 1.0.0 to 2.1.0 (package.json:2)## Description